### PR TITLE
fix Makefile to run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ endif
 
 ifeq (, $(shell which go-bindata))
 	@echo "Installing go-bindata..."
-	@go install github.com/kevinburke/go-bindata/go-bindata@latest
+	@go install github.com/kevinburke/go-bindata/v4/go-bindata@latest
 else
 	@echo "go-bindata already installed; skipping..."
 endif
@@ -71,7 +71,7 @@ endif
 
 ifeq (, $(shell which protoc-gen-go))
 	@echo "Installing protoc-gen-go..."
-	@go install github.com/fjl/gencodeclatest
+	@go install github.com/fjl/gencodec@latest
 	@go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 else
 	@echo "protoc-gen-go already installed; skipping..."
@@ -99,7 +99,7 @@ endif
 
 ifeq (, $(shell which solc))
 	@echo "Installing solc..."
-	@snap install solc
+	@sudo snap install solc
 else
 	@echo "solc already installed; skipping..."
 endif


### PR DESCRIPTION
I looked at your github readme and tried to run the "make contract-tools" command, but it failed.
I saw that there was a slight problem with the makefile.
So I fixed it, and check that it worked fine when I ran it.
As you can see from the changes, I fixed the different method that go-bindata uses to install, 
I fixed the use of gencodec@latest without @,
and I fixed the snap install solc part to install with sudo as it kept failing because it didn't have sudo.
A pull request would be appreciated. Thank you.